### PR TITLE
removing nodeselector

### DIFF
--- a/chart/base/values.yaml
+++ b/chart/base/values.yaml
@@ -33,10 +33,6 @@ vcsInfo:
 partOf: ''
 connectsTo: ''
 runtime: js
-
-nodeSelector:
-  kubernetes.io/hostname: 10.23.5.110
-
 env:
   - name: PORT
     value: 8080


### PR DESCRIPTION
Helm was tested and succeeded, we had to remove the nodeselector it, as it was forcing us to use the same worker node IP  